### PR TITLE
[CR#133910] Amélioration de l'AbstractEntityService

### DIFF
--- a/Tests/Model.php
+++ b/Tests/Model.php
@@ -42,6 +42,11 @@ class Model extends AbstractEntity
         $this->created_at = $this->updated_at = $this->deleted_at = $date;
     }
 
+    public function setCreatedAt(\DateTime $created_at)
+    {
+        $this->created_at = $created_at;
+    }
+
     public function jsonSerialize()
     {
         return [

--- a/Tests/ModelService.php
+++ b/Tests/ModelService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests;
+
+use ETNA\Doctrine\Entity\AbstractEntityService;
+
+class ModelService extends AbstractEntityService
+{
+    public function __construct($em, $validator)
+    {
+        parent::__construct($em, $validator);
+    }
+
+    public function create($datas)
+    {
+        $model = new Model();
+
+        $this->setPropertiesToEntity($datas, ['create'], $model);
+
+        return $model;
+    }
+}

--- a/Tests/ModelTest.php
+++ b/Tests/ModelTest.php
@@ -135,14 +135,15 @@ class ModelTest extends \PHPUnit\Framework\TestCase
         ];
 
         $validation_fake_metas->members = [
-            "model_value" => [$fake_constraints]
+            "model_value" => [$fake_constraints],
+            "created_at"  => [$fake_constraints]
         ];
 
         $doctrine_fake_metas->fieldMappings = [
             "model_value" => ["fieldName" => "model_value", "type" => "string"],
-            "created_at"  => ["fieldName" => "created_at",  "type" => "string"],
-            "updated_at"  => ["fieldName" => "updated_at",  "type" => "string"],
-            "deleted_at"  => ["fieldName" => "deleted_at",  "type" => "string"],
+            "created_at"  => ["fieldName" => "created_at",  "type" => "datetime"],
+            "updated_at"  => ["fieldName" => "updated_at",  "type" => "datetime"],
+            "deleted_at"  => ["fieldName" => "deleted_at",  "type" => "datetime"],
         ];
 
         $em = $this->createMock(\Doctrine\ORM\EntityManager::class);
@@ -152,11 +153,13 @@ class ModelTest extends \PHPUnit\Framework\TestCase
         $model_service = new ModelService($em, $validator);
 
         $model = $model_service->create([
-            'model_value' => 'je suis une super valeur',
+            'model_value'   => 'je suis une super valeur',
             'useless_value' => 'mais moi je sers a rien',
-            'created_at' => 'tentative de hacking'
+            'created_at'    => '2012-12-21 12:12:12',
+            'updated_at'    => 'j\'suis trop un hacker'
         ]);
 
         $this->assertEquals($model->getModelValue(), 'je suis une super valeur');
+        $this->assertEquals($model->getCreatedAt('Y-m-d H:i:s'), '2012-12-21 12:12:12');
     }
 }

--- a/Tests/ModelTest.php
+++ b/Tests/ModelTest.php
@@ -124,4 +124,39 @@ class ModelTest extends \PHPUnit\Framework\TestCase
         $this->model->setProperties(["model_value" => "super value"]);
         $this->assertEquals($this->model->getModelValue(), "super value");
     }
+
+    public function testModelService()
+    {
+        $doctrine_fake_metas = new \stdClass();
+        $validation_fake_metas = new \stdClass();
+        $fake_constraints = new \stdClass();
+        $fake_constraints->constraintsByGroup = [
+            "create" => []
+        ];
+
+        $validation_fake_metas->members = [
+            "model_value" => [$fake_constraints]
+        ];
+
+        $doctrine_fake_metas->fieldMappings = [
+            "model_value" => ["fieldName" => "model_value", "type" => "string"],
+            "created_at"  => ["fieldName" => "created_at",  "type" => "string"],
+            "updated_at"  => ["fieldName" => "updated_at",  "type" => "string"],
+            "deleted_at"  => ["fieldName" => "deleted_at",  "type" => "string"],
+        ];
+
+        $em = $this->createMock(\Doctrine\ORM\EntityManager::class);
+        $em->method('getClassMetadata')->willReturn($doctrine_fake_metas);
+        $validator = $this->createMock(\Symfony\Component\Validator\Validator\RecursiveValidator::class);
+        $validator->method('getMetadataFor')->willReturn($validation_fake_metas);
+        $model_service = new ModelService($em, $validator);
+
+        $model = $model_service->create([
+            'model_value' => 'je suis une super valeur',
+            'useless_value' => 'mais moi je sers a rien',
+            'created_at' => 'tentative de hacking'
+        ]);
+
+        $this->assertEquals($model->getModelValue(), 'je suis une super valeur');
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "php": ">=7.1",
-        "doctrine/orm": "2.x@stable"
+        "doctrine/orm": "2.x@stable",
+        "symfony/validator": "^4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c80f7d58dfe2a316deb4f57a3480d5e4",
+    "content-hash": "4a933f1d39f22112802721f765fb5948",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1016,6 +1016,64 @@
             "time": "2019-04-27T14:29:50+00:00"
         },
         {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.11.0",
             "source": {
@@ -1073,6 +1131,95 @@
                 "shim"
             ],
             "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/validator",
+            "version": "v4.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "32cc317e980da350ea73dde9d64729146048ef20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/32cc317e980da350ea73dde9d64729146048ef20",
+                "reference": "32cc317e980da350ea73dde9d64729146048ef20",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/http-kernel": "<3.4",
+                "symfony/intl": "<4.1",
+                "symfony/translation": "<4.2",
+                "symfony/yaml": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "egulias/email-validator": "^1.2.8|~2.0",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/http-foundation": "~4.1",
+                "symfony/http-kernel": "~3.4|~4.0",
+                "symfony/intl": "~4.1",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/translation": "~4.2",
+                "symfony/var-dumper": "~3.4|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
+                "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+                "egulias/email-validator": "Strict (RFC compliant) email validation",
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "",
+                "symfony/expression-language": "For using the Expression validator",
+                "symfony/http-foundation": "",
+                "symfony/intl": "",
+                "symfony/property-access": "For accessing properties within comparison constraints",
+                "symfony/translation": "For translating validation errors.",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Validator\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Validator Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-05-09T13:04:55+00:00"
         }
     ],
     "packages-dev": [
@@ -3418,64 +3565,6 @@
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "time": "2019-04-06T13:51:08+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/src/Entity/AbstractEntityService.php
+++ b/src/Entity/AbstractEntityService.php
@@ -20,7 +20,9 @@ abstract class AbstractEntityService
     }
 
     /**
-     * Filtre les champs de $datas qui correspondent à ceux de $entity en se basant sur les groupes de validations.
+     * Filtre les champs directs (pas les jointures) de $datas, en fonction des groupes de validation
+     * Et rempli l'entité avec les données filtrées, et éventuellement re-typées.
+
      * Permet de scénariser les modifications d'entités grace aux groupes de validation.
      *
      * @see https://symfony.com/doc/current/validation/groups.html
@@ -31,20 +33,36 @@ abstract class AbstractEntityService
      *
      * @return array
      */
-    protected function filterDataByValidationGroups(array $datas, array $validation_groups, AbstractEntity $entity)
+    protected function setPropertiesToEntity(array $datas, array $validation_groups, AbstractEntity $entity)
     {
-        $entity_members_metadatas = $this->validator->getMetadataFor($entity)->members;
-        $filtered_datas           = [];
+        $filtered_datas            = [];
+        $validation_field_metadata = $this->validator->getMetadataFor($entity)->members;
+        $doctrine_field_metadata   = $this->em->getClassMetadata(get_class($entity))->fieldMappings;
+        $all_fields                = array_keys($doctrine_field_metadata);
 
-        foreach ($entity_members_metadatas as $field_name => $all_field_metadatas) {
-            $constraints             = array_shift($all_field_metadatas);
+        foreach ($datas as $field_name => $data_value) {
+            $constraints             = array_shift($validation_field_metadata[$field_name]);
             $field_validation_groups = array_keys($constraints->constraintsByGroup);
             $is_field_concerned      = !empty(array_intersect($validation_groups, $field_validation_groups));
 
-            if ($is_field_concerned && isset($datas[$field_name])) {
-                $filtered_datas[$field_name] = $datas[$field_name];
+            switch (true) {
+                // Si la data concerne un champ qui ne fait pas parti de l'entité, on passe
+                case !in_array($field_name, $all_fields) || !$is_field_concerned:
+                    break;
+                // Si la data concerne un champ date ou assimilé, et que c'est une string, on sette un DateTime
+                case 1 === preg_match(
+                    "#^(date|datetime|time)[a-z_]*$#",
+                    $doctrine_field_metadata[$field_name]["type"]
+                ) && is_string($data_value):
+                    $filtered_datas[$field_name] = new \DateTime($data_value);
+                    break;
+                // Sinon on sette tel quel
+                default:
+                    $filtered_datas[$field_name] = $data_value;
+                    break;
             }
         }
-        return $filtered_datas;
+
+        $entity->setProperties($filtered_datas);
     }
 }

--- a/src/Entity/AbstractEntityService.php
+++ b/src/Entity/AbstractEntityService.php
@@ -41,9 +41,13 @@ abstract class AbstractEntityService
         $all_fields                = array_keys($doctrine_field_metadata);
 
         foreach ($datas as $field_name => $data_value) {
-            $constraints             = array_shift($validation_field_metadata[$field_name]);
-            $field_validation_groups = array_keys($constraints->constraintsByGroup);
-            $is_field_concerned      = !empty(array_intersect($validation_groups, $field_validation_groups));
+            $is_field_concerned = false;
+
+            if (isset($validation_field_metadata[$field_name])) {
+                $constraints             = array_shift($validation_field_metadata[$field_name]);
+                $field_validation_groups = array_keys($constraints->constraintsByGroup);
+                $is_field_concerned      = !empty(array_intersect($validation_groups, $field_validation_groups));
+            }
 
             switch (true) {
                 // Si la data concerne un champ qui ne fait pas parti de l'entité, on passe


### PR DESCRIPTION
On remplace la fonction de filtre par une fonction qui va directement setter les datas
De plus on filtre en n'utilisant uniquement les champs directs d'une table, pour le reste c'est l'implémentation du service qui gèrera au besoin

On gère aussi les types de dates pour les datas, pour ne pas frustrer les setters